### PR TITLE
CMake fixes/rework for packaging. User support for retrieving self.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -73,7 +73,17 @@ You will need to invoke it from a Unix shell with access to the compilers on
 your platform. (On Windows, this would be the Git Bash shell.)
 
 ```bash
-just t=Release build  # Use t=Debug for a debug build
+just build       # Build library (default type=Debug)
+
+just             # Display help list of defaults/options
+
+just type=Release build    # Build a Release build
+just release     # Short cut for type=Release
+
+just version     # Display current library version
+just -s version  # Show steps in version recipe
+
+just shared=False type=Release build  # Build a static, release library
 ```
 
 Expect this to take a while.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -9,7 +9,7 @@ if Conan or CMake should build the library is related to how you will consume
 the library. We also recommend that you use
 [Just](https://github.com/casey/just) to automate the build steps.
 
-Conan is a tool for managing C++ dependencies and if you are writing an
+*Conan* is a tool for managing C++ dependencies and if you are writing an
 application which depends on this library and is using Conan already, it is
 trivial to add as an external dependency which handles the cross-platform and
 versioning aspects for you.
@@ -86,13 +86,12 @@ just -s version  # Show steps in version recipe
 just shared=False type=Release build  # Build a static, release library
 ```
 
-Expect this to take a while.
+Expect this to take a while. Please see the [Build Artifacts](#build-artifacts)
+section below to find the artifacts that you built.
 
 If you don't want to use `Just`, you can follow the steps below, manually.
 
----
-
-## Building with Conan and CMake
+## Building manually using Conan and CMake (alternative to `Just`)
 
 ### Installing dependencies using Conan
 
@@ -145,7 +144,7 @@ cmake --build . --config Release
 cmake --build . --config Release --target ALL_BUILD
 ```
 
-### Build artifacts
+## Build artifacts
 
 You can find the library that was built in `build/Release/`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [1.1.0]
+ - Added User support for retrieve/update operating on self when the
+   id and email are not provided. When id and email are provided, the
+   API uses the Organization end-points to update another user but
+   requires connected with the appropriate ROLE.
+ - Added dfxcli get user flag -s to operate on self
+ - Fixed issue with User DateOfBirth which was inconsistently handled
+   between WebSocket/REST (string) and gRPC (epoch). gRPC now uses
+   the same field and uses the string representation.
+ - Updated the conanfile to pull the version from the CMakeLists to
+   ensure version is known consistently to CMake when constructing
+   library.
+ - Added CMake configure install/configure packages so package can
+   be installed and found using find_package in another package.
+ - CMakeLists dependencies more controlled and created separate
+   projects for dfxcli and test, both of which can be build standalone.
+ - Cleaned the library name up to be known as "libdfxcloud" matching
+   find_package.
+
+## [1.0.0]
+ - Initial release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+
+# conanfile.py parses next line to determine version which feeds the version to everything
+set(DFX_CLOUD_LIBRARY_VERSION 1.1.0)
+
 project(
-  dfxapi
-  VERSION 1.3
+  dfxcloud
+  VERSION ${DFX_CLOUD_LIBRARY_VERSION}
   LANGUAGES CXX C)
 
 # Using (at least) C++11 Features: using to write type aliases like typedefs Using (at least) C++17 Features:
@@ -99,6 +103,14 @@ list(PREPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_BINARY_DIR}/cma
                                                                                    # Conan (for proto gen)
 )
 
+if(DEFINED CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  message(STATUS "CMAKE_INSTALL_PREFIX is not set\n" "Default value: ${CMAKE_INSTALL_PREFIX}\n"
+                 "Will set it to ${CMAKE_BINARY_DIR}/install")
+  set(CMAKE_INSTALL_PREFIX
+      "${CMAKE_BINARY_DIR}/install"
+      CACHE PATH "Where the library will be installed to" FORCE)
+endif()
+
 include(find_dependencies)
 
 if(EMBED_CA_CERTS)
@@ -112,12 +124,6 @@ endif(BUILD_SHARED_LIBS)
 # GNUInstallDirs to install libraries into correct locations on all platform
 include(GNUInstallDirs)
 
-if(WITH_TESTS)
-  include(CTest)
-  include(GoogleTest)
-  enable_testing()
-endif()
-
 add_subdirectory(api-utils)
 add_subdirectory(api-protos-web)
 add_subdirectory(api-protos-grpc)
@@ -128,35 +134,40 @@ add_subdirectory(api-cpp-rest)
 add_subdirectory(websocket) # Provide an implementation for api-cpp-websockets to use
 add_subdirectory(api-cpp-websocket)
 add_subdirectory(doc)
-add_subdirectory(test)
-add_subdirectory(tool-dfxcli)
 
-add_library(dfxapi api-protos-grpc api-cpp api-utils $<$<BOOL:${WITH_GRPC}>:api-cpp-grpc>
-                   $<$<BOOL:${WITH_REST}>:api-cpp-rest> $<$<BOOL:${WITH_WEBSOCKET}>:api-cpp-websocket>)
+add_library(dfxcloud "")
+add_library(DFXCloud::dfxcloud ALIAS dfxcloud)
+
+if(WITH_DFXCLI)
+  add_subdirectory(tool-dfxcli)
+endif(WITH_DFXCLI)
+
+if(WITH_TESTS)
+  add_subdirectory(test)
+endif(WITH_TESTS)
 
 if(MSVC AND CMAKE_BUILD_TYPE MATCHES DEBUG) # Microsoft compiler flag
   # LNK4099 PDB 'filename' was not found with 'object/library' or at 'path'; linking object as if no debug
   # info
-  target_compile_options(dfxapi PUBLIC /wd4099)
-  set_target_properties(dfxapi PROPERTIES LINK_FLAGS "/ignore:4099")
+  target_compile_options(dfxcloud PUBLIC /wd4099)
+  set_target_properties(dfxcloud PROPERTIES LINK_FLAGS "/ignore:4099")
 endif(MSVC AND CMAKE_BUILD_TYPE MATCHES DEBUG)
 
 target_link_libraries(
-  dfxapi
+  dfxcloud
   PUBLIC api-cpp api-utils
-  PRIVATE $<$<BOOL:${WITH_GRPC}>:api-protos-grpc>
-          api-protos-web
-          api-cpp-validator # stub if not WITH_VALIDATORS
-          protobuf::protobuf
-          $<$<BOOL:${WITH_GRPC}>:api-cpp-grpc>
-          $<$<BOOL:${WITH_REST}>:api-cpp-rest>
-          $<$<BOOL:${WITH_WEBSOCKET}>:api-cpp-websocket>
-          $<$<BOOL:${WITH_WEBSOCKET}>:websocket>)
+  PRIVATE protobuf::protobuf
+          $<TARGET_OBJECTS:api-protos-web>
+          $<$<BOOL:${WITH_GRPC}>:$<TARGET_OBJECTS:api-protos-grpc>>
+          $<$<BOOL:${WITH_GRPC}>:$<TARGET_OBJECTS:api-cpp-grpc>>
+          $<$<BOOL:${WITH_REST}>:$<TARGET_OBJECTS:api-cpp-rest>>
+          $<$<BOOL:${WITH_WEBSOCKET}>:$<TARGET_OBJECTS:api-cpp-websocket>>
+          $<$<BOOL:${WITH_WEBSOCKET}>:$<TARGET_OBJECTS:websocket>>)
 
 # When not including gRPC, Undefined symbols for architecture arm64: "_CFRelease", referenced from:
 # _Curl_resolv in libcurl.a(libcurl_la-hostip.o)
 if(APPLE)
-  target_link_libraries(dfxapi PRIVATE "-framework CoreFoundation")
+  target_link_libraries(dfxcloud PRIVATE "-framework CoreFoundation")
 endif()
 
 if(APPLE)
@@ -186,46 +197,66 @@ else()
 endif()
 
 if(APPLE)
-  set_target_properties(dfxapi PROPERTIES INSTALL_RPATH "@executable_path/../lib")
+  set_target_properties(dfxcloud PROPERTIES INSTALL_RPATH "@executable_path/../lib")
 elseif(WIN32)
   # NO @RPATH on Windows
 else()
-  set_target_properties(dfxapi PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
+  set_target_properties(dfxcloud PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
 endif()
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   if(NOT EMSCRIPTEN)
     if(APPLE)
       set_target_properties(
-        dfxapi PROPERTIES LINK_FLAGS
-                          "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/cmake/clang-exports")
+        dfxcloud PROPERTIES LINK_FLAGS
+                            "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/cmake/clang-exports")
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       set_target_properties(
-        dfxapi PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/cmake/gcc-exports")
+        dfxcloud PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/cmake/gcc-exports")
     endif()
   endif()
 
   if(CMAKE_STRIP AND NOT EMSCRIPTEN)
     if(UNIX) # Same for both OSX and Linux
       add_custom_command(
-        TARGET dfxapi
+        TARGET dfxcloud
         POST_BUILD
-        COMMAND ${CMAKE_STRIP} -x $<TARGET_FILE:dfxapi>)
+        COMMAND ${CMAKE_STRIP} -x $<TARGET_FILE:dfxcloud>)
     endif()
   endif()
 endif()
 
+# This will not work on Windows if generated against an object library as there is implicit CMake defines
+# being injected for the real library being generated, in this case dfxcloud.
+include(GenerateExportHeader)
+generate_export_header(dfxcloud BASE_NAME DFXCLOUD EXPORT_FILE_NAME include/dfx/api/CloudAPI_Export.hpp)
+add_definitions(-Ddfxcloud_EXPORTS)
+
 install(
-  TARGETS dfxapi
+  TARGETS dfxcloud
+  EXPORT DFXCloud-export
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}) # This is for Windows
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION include-bad/)
 
-# This will not work on Windows if generated against an object library as there is implicit CMake defines
-# being injected for the real library being generated, in this case dfxapi.
-include(GenerateExportHeader)
-generate_export_header(dfxapi BASE_NAME DFXCLOUD EXPORT_FILE_NAME include/dfx/api/CloudAPI_Export.hpp)
-add_definitions(-Ddfxapi_EXPORTS)
+install(
+  EXPORT DFXCloud-export
+  FILE DFXCloudTargets.cmake
+  NAMESPACE DFXCloud::
+  DESTINATION lib/cmake/DFXCloud)
+
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DFXCloudConfig.cmake DESTINATION "lib/cmake/DFXCloud")
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/dfx/api/CloudAPI_Export.hpp" DESTINATION include/dfx/api)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/DFXCloudConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/DFXCloudConfigVersion.cmake DESTINATION "lib/cmake/DFXCloud")
 
 if(ENABLE_CHECKS)
   include(cmake/clang-tidy.cmake)
@@ -244,6 +275,7 @@ message(STATUS "")
 message(STATUS "    Target Host:  ${CMAKE_SYSTEM_NAME}, Arch: ${CMAKE_SYSTEM_PROCESSOR}")
 message(STATUS "    CXX COMPILER: ${CMAKE_CXX_COMPILER}    (${CMAKE_CXX_COMPILER_VERSION})")
 message(STATUS "    CMAKE_TOOLCHAIN_FILE: ${CMAKE_TOOLCHAIN_FILE}")
+message(STATUS "    CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
 message(STATUS "")
 message(STATUS "    BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 message(STATUS "    SHARED_LIBS=${BUILD_SHARED_LIBS}")
@@ -262,7 +294,7 @@ message(STATUS "")
 message(STATUS "    EMBED_CA_CERTS=${EMBED_CA_CERTS}")
 message(STATUS "")
 
-set(CMAKE_DUMP_PROPS ON)
+set(CMAKE_DUMP_PROPS OFF)
 if(CMAKE_DUMP_PROPS)
   get_cmake_property(_variableNames VARIABLES)
   foreach(_variableName ${_variableNames})

--- a/api-cpp-grpc/CMakeLists.txt
+++ b/api-cpp-grpc/CMakeLists.txt
@@ -3,14 +3,14 @@ if(NOT WITH_GRPC)
 endif(NOT WITH_GRPC)
 
 # Use an absolute reference here so that doxygen can locate in the doc context by target
-set(API_CPP_GRPC_PUBLIC_HEADERS
-    ${CMAKE_SOURCE_DIR}/api-cpp-grpc/include/dfx/api/grpc/CloudGRPC.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-grpc/include/dfx/api/grpc/DeviceGRPC.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-grpc/include/dfx/api/grpc/MeasurementGRPC.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-grpc/include/dfx/api/grpc/MeasurementStreamGRPC.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-grpc/include/dfx/api/grpc/SignalGRPC.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-grpc/include/dfx/api/grpc/StudyGRPC.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-grpc/include/dfx/api/grpc/UserGRPC.hpp)
+set(API_CPP_GRPC_HEADERS
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/grpc/CloudGRPC.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/grpc/DeviceGRPC.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/grpc/MeasurementGRPC.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/grpc/MeasurementStreamGRPC.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/grpc/SignalGRPC.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/grpc/StudyGRPC.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/grpc/UserGRPC.hpp)
 
 add_library(
   api-cpp-grpc OBJECT
@@ -22,7 +22,8 @@ add_library(
   src/MeasurementStreamGRPC.cpp
   src/SignalGRPC.cpp
   src/StudyGRPC.cpp
-  src/UserGRPC.cpp)
+  src/UserGRPC.cpp
+  ${API_CPP_GRPC_HEADERS})
 
 if(MSVC)
   # Silence the Microsoft compiler warnings C4996/STL4015, for generated gRPC code when building with C++17
@@ -36,21 +37,18 @@ if(MSVC)
   target_compile_options(api-cpp-grpc PUBLIC /utf-8)
 endif()
 
-# set_target_properties(api-cpp-grpc PROPERTIES DEFINE_SYMBOL "dfxapi_EXPORTS")
-target_compile_definitions(api-cpp-grpc PRIVATE -Ddfxapi_EXPORTS)
+target_compile_definitions(api-cpp-grpc PRIVATE -Ddfxcloud_EXPORTS)
 
 target_include_directories(
   api-cpp-grpc
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<BUILD_INTERFACE:$<TARGET_PROPERTY:gRPC::grpc++,INTERFACE_INCLUDE_DIRECTORIES>>
   PRIVATE $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-cpp,INTERFACE_INCLUDE_DIRECTORIES>>
-          $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-protos-grpc,INTERFACE_INCLUDE_DIRECTORIES>>)
+          $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-cpp-validator,INTERFACE_INCLUDE_DIRECTORIES>>
+          $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-protos-grpc,INTERFACE_INCLUDE_DIRECTORIES>>
+          $<BUILD_INTERFACE:$<TARGET_PROPERTY:fmt::fmt,INTERFACE_INCLUDE_DIRECTORIES>>)
 
-set_target_properties(api-cpp-grpc PROPERTIES PUBLIC_HEADER "${API_CPP_GRPC_PUBLIC_HEADERS}")
-
+# gRPC seems to have a couple absl libraries which need to be added explicitly to satisfy link requirements
 target_link_libraries(
-  api-cpp-grpc protobuf::protobuf gRPC::grpc++ absl::random_internal_randen_hwaes_impl # implicit gRPC
-                                                                                       # libgrpc.a
-  absl::random_internal_pool_urbg # implicit gRPC libgrpc.a
-)
-
-install(TARGETS api-cpp-grpc PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dfx/api/grpc)
+  api-cpp-grpc PRIVATE protobuf::protobuf gRPC::grpc++ absl::random_internal_randen_hwaes_impl
+                       absl::random_internal_pool_urbg)

--- a/api-cpp-grpc/include/dfx/api/grpc/UserGRPC.hpp
+++ b/api-cpp-grpc/include/dfx/api/grpc/UserGRPC.hpp
@@ -44,10 +44,15 @@ public:
                      std::vector<User>& users,
                      int16_t& totalCount) override;
 
+    CloudStatus retrieve(const CloudConfig& config, User& user) override;
+
+    CloudStatus update(const CloudConfig& config, const User& user) override;
+
     CloudStatus
     retrieve(const CloudConfig& config, const std::string& userID, const std::string& email, User& user) override;
 
-    CloudStatus update(const CloudConfig& config, const User& user) override;
+    CloudStatus
+    update(const CloudConfig& config, const std::string& userID, const std::string& email, const User& user) override;
 
     CloudStatus remove(const CloudConfig& config, const std::string& userID, const std::string& email) override;
 

--- a/api-cpp-grpc/src/CloudGRPC.cpp
+++ b/api-cpp-grpc/src/CloudGRPC.cpp
@@ -3,7 +3,6 @@
 
 #include "dfx/auth/v1/auth.grpc.pb.h"
 #include "dfx/devices/v2/devices.grpc.pb.h"
-#include "dfx/measurements/v2/measurements.grpc.pb.h"
 
 #include "dfx/api/OrganizationAPI.hpp"
 

--- a/api-cpp-grpc/src/UserGRPC.cpp
+++ b/api-cpp-grpc/src/UserGRPC.cpp
@@ -12,8 +12,8 @@
 #include "CloudGRPCMacros.hpp"
 #include <ctime>
 #include <fmt/format.h>
-#include <sstream>
 #include <iomanip>
+#include <sstream>
 
 using dfx::api::CloudAPI;
 using dfx::api::CloudConfig;

--- a/api-cpp-grpc/src/UserGRPC.cpp
+++ b/api-cpp-grpc/src/UserGRPC.cpp
@@ -12,6 +12,8 @@
 #include "CloudGRPCMacros.hpp"
 #include <ctime>
 #include <fmt/format.h>
+#include <sstream>
+#include <iomanip>
 
 using dfx::api::CloudAPI;
 using dfx::api::CloudConfig;
@@ -36,9 +38,9 @@ std::string epocToString(uint64_t when)
 
 uint64_t strToEpoch(const std::string& str)
 {
-    std::tm tmTime;
-    memset(&tmTime, 0, sizeof(tmTime));
-    strptime(str.c_str(), "%F", &tmTime);
+    std::tm tmTime = {};
+    std::istringstream ss(str);
+    ss >> std::get_time(&tmTime, "%Y-%m-%d");
     return mktime(&tmTime);
 }
 
@@ -223,6 +225,7 @@ UserGRPC::retrieve(const CloudConfig& config, const std::string& userID, const s
         user.avatarURL = userData.avatar_uri();
         user.createdEpochSeconds = userData.created().seconds();
         user.updatedEpochSeconds = userData.updated().seconds();
+        user.dateOfBirth = epocToString(userData.date_of_birth().seconds());
     }
 
     return CloudStatus(CLOUD_OK);

--- a/api-cpp-rest/CMakeLists.txt
+++ b/api-cpp-rest/CMakeLists.txt
@@ -5,16 +5,16 @@ endif(NOT WITH_REST)
 add_definitions(-DWITH_REST)
 
 # Use an absolute reference here so that doxygen can locate in the doc context by target
-set(API_CPP_REST_PUBLIC_HEADERS
-    ${CMAKE_SOURCE_DIR}/api-cpp-rest/include/dfx/api/rest/DeviceREST.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-rest/include/dfx/api/rest/LicenseREST.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-rest/include/dfx/api/rest/MeasurementREST.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-rest/include/dfx/api/rest/MeasurementStreamREST.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-rest/include/dfx/api/rest/OrganizationREST.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-rest/include/dfx/api/rest/ProfileREST.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-rest/include/dfx/api/rest/SignalREST.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-rest/include/dfx/api/rest/StudyREST.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-rest/include/dfx/api/rest/UserREST.hpp)
+set(API_CPP_REST_HEADERS
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/rest/DeviceREST.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/rest/LicenseREST.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/rest/MeasurementREST.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/rest/MeasurementStreamREST.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/rest/OrganizationREST.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/rest/ProfileREST.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/rest/SignalREST.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/rest/StudyREST.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/rest/UserREST.hpp)
 
 add_library(
   api-cpp-rest OBJECT
@@ -28,7 +28,7 @@ add_library(
   src/SignalREST.cpp
   src/StudyREST.cpp
   src/UserREST.cpp
-  ${API_CPP_REST_PUBLIC_HEADERS})
+  ${API_CPP_REST_HEADERS})
 
 if(MSVC)
   if(BUILD_SHARED_LIBS)
@@ -38,15 +38,15 @@ if(MSVC)
   target_compile_options(api-cpp-rest PUBLIC /utf-8)
 endif()
 
-target_compile_definitions(api-cpp-rest PRIVATE -Ddfxapi_EXPORTS)
+target_compile_definitions(api-cpp-rest PRIVATE -Ddfxcloud_EXPORTS)
 
 target_include_directories(
   api-cpp-rest
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-         $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-cpp,INTERFACE_INCLUDE_DIRECTORIES>>)
-
-set_target_properties(api-cpp-rest PROPERTIES PUBLIC_HEADER "${API_CPP_REST_PUBLIC_HEADERS}")
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-protos-web,INTERFACE_INCLUDE_DIRECTORIES>>
+  PRIVATE $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-cpp,INTERFACE_INCLUDE_DIRECTORIES>>
+          $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-cpp-validator,INTERFACE_INCLUDE_DIRECTORIES>>
+          $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-utils,INTERFACE_INCLUDE_DIRECTORIES>>)
 
 set_target_properties(api-cpp-rest PROPERTIES CXX_VISIBILITY_PRESET hidden)
 

--- a/api-cpp-rest/include/dfx/api/rest/UserREST.hpp
+++ b/api-cpp-rest/include/dfx/api/rest/UserREST.hpp
@@ -40,10 +40,15 @@ public:
                      std::vector<User>& users,
                      int16_t& totalCount) override;
 
+    CloudStatus retrieve(const CloudConfig& config, User& user) override;
+
+    CloudStatus update(const CloudConfig& config, const User& user) override;
+
     CloudStatus
     retrieve(const CloudConfig& config, const std::string& userID, const std::string& email, User& user) override;
 
-    CloudStatus update(const CloudConfig& config, const User& user) override;
+    CloudStatus
+    update(const CloudConfig& config, const std::string& userID, const std::string& email, const User& user) override;
 
     CloudStatus remove(const CloudConfig& config, const std::string& userID, const std::string& email) override;
 

--- a/api-cpp-rest/src/UserREST.cpp
+++ b/api-cpp-rest/src/UserREST.cpp
@@ -74,13 +74,11 @@ CloudStatus UserREST::list(const CloudConfig& config,
     return CloudStatus(CLOUD_UNSUPPORTED_FEATURE, fmt::format("{} does not support {} end-point", "REST", "user list"));
 }
 
-CloudStatus
-UserREST::retrieve(const CloudConfig& config, const std::string& userID, const std::string& email, User& user)
+CloudStatus UserREST::retrieve(const CloudConfig& config, User& user)
 {
-    DFX_CLOUD_VALIDATOR_MACRO(UserValidator, retrieve(config, userID, email, user));
+    DFX_CLOUD_VALIDATOR_MACRO(UserValidator, retrieve(config, user));
     json response, request;
-    auto status = CloudREST::performRESTCall(
-        config, web::Organizations::RetrieveUser, config.authToken, {userID}, request, response);
+    auto status = CloudREST::performRESTCall(config, web::Users::Retrieve, config.authToken, {}, request, response);
     if (status.OK()) {
         user = response;
     }
@@ -91,6 +89,34 @@ UserREST::retrieve(const CloudConfig& config, const std::string& userID, const s
 CloudStatus UserREST::update(const CloudConfig& config, const User& user)
 {
     DFX_CLOUD_VALIDATOR_MACRO(UserValidator, update(config, user));
+
+    json response, request;
+    request = user;
+    auto status = CloudREST::performRESTCall(config, web::Users::Update, config.authToken, {}, request, response);
+
+    return status;
+}
+
+CloudStatus
+UserREST::retrieve(const CloudConfig& config, const std::string& userID, const std::string& email, User& user)
+{
+    // Ignore email check for empty, REST call is going to ignore it anyway
+    DFX_CLOUD_VALIDATOR_MACRO(UserValidator, retrieve(config, userID, "email", user));
+    json response, request;
+    auto status = CloudREST::performRESTCall(
+        config, web::Organizations::RetrieveUser, config.authToken, {userID}, request, response);
+    if (status.OK()) {
+        user = response;
+    }
+
+    return status;
+}
+
+CloudStatus
+UserREST::update(const CloudConfig& config, const std::string& userID, const std::string& email, const User& user)
+{
+    // Ignore email check for empty, REST call is going to ignore it anyway
+    DFX_CLOUD_VALIDATOR_MACRO(UserValidator, update(config, userID, "email", user));
 
     json response, request;
     request = user;

--- a/api-cpp-validator/CMakeLists.txt
+++ b/api-cpp-validator/CMakeLists.txt
@@ -8,17 +8,17 @@ endif(NOT WITH_VALIDATORS)
 add_definitions(-DWITH_VALIDATORS)
 
 # Use an absolute reference here so that doxygen can locate in the doc context by target
-set(API_CPP_VALIDATOR_PUBLIC_HEADERS
-    ${CMAKE_SOURCE_DIR}/api-cpp-validator/include/dfx/api/validator/CloudValidator.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-validator/include/dfx/api/validator/DeviceValidator.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-validator/include/dfx/api/validator/LicenseValidator.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-validator/include/dfx/api/validator/MeasurementValidator.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-validator/include/dfx/api/validator/MeasurementStreamValidator.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-validator/include/dfx/api/validator/OrganizationValidator.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-validator/include/dfx/api/validator/ProfileValidator.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-validator/include/dfx/api/validator/SignalValidator.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-validator/include/dfx/api/validator/StudyValidator.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-validator/include/dfx/api/validator/UserValidator.hpp)
+set(API_CPP_VALIDATOR_HEADERS
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/validator/CloudValidator.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/validator/DeviceValidator.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/validator/LicenseValidator.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/validator/MeasurementValidator.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/validator/MeasurementStreamValidator.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/validator/OrganizationValidator.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/validator/ProfileValidator.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/validator/SignalValidator.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/validator/StudyValidator.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/validator/UserValidator.hpp)
 
 add_library(
   api-cpp-validator OBJECT
@@ -32,7 +32,8 @@ add_library(
   src/SignalValidator.cpp
   src/StudyValidator.cpp
   src/UserValidator.cpp
-  src/CloudValidatorMacros.hpp)
+  src/CloudValidatorMacros.hpp
+  ${API_CPP_VALIDATOR_HEADERS})
 
 if(MSVC)
   if(BUILD_SHARED_LIBS)
@@ -42,17 +43,14 @@ if(MSVC)
   target_compile_options(api-cpp-validator PUBLIC /utf-8)
 endif()
 
-set_target_properties(api-cpp-validator PROPERTIES DEFINE_SYMBOL "dfxapi_EXPORTS")
+set_target_properties(api-cpp-validator PROPERTIES DEFINE_SYMBOL "dfxcloud_EXPORTS")
 
 target_include_directories(
   api-cpp-validator
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src> # for ValidatorMacros.hpp
-          $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-cpp,INTERFACE_INCLUDE_DIRECTORIES>>)
-
-set_target_properties(api-cpp-validator PROPERTIES PUBLIC_HEADER "${API_CPP_VALIDATOR_PUBLIC_HEADERS}")
+          $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-cpp,INTERFACE_INCLUDE_DIRECTORIES>>
+          $<BUILD_INTERFACE:$<TARGET_PROPERTY:fmt::fmt,INTERFACE_INCLUDE_DIRECTORIES>>)
 
 set_target_properties(api-cpp-validator PROPERTIES CXX_VISIBILITY_PRESET hidden)
 set_target_properties(api-cpp-validator PROPERTIES CMAKE_VISIBILITY_INLINES_HIDDEN YES)
-
-install(TARGETS api-cpp-validator PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dfx/api/validator)

--- a/api-cpp-validator/include/dfx/api/validator/UserValidator.hpp
+++ b/api-cpp-validator/include/dfx/api/validator/UserValidator.hpp
@@ -37,10 +37,15 @@ public:
                      std::vector<User>& users,
                      int16_t& totalCount) override;
 
+    CloudStatus retrieve(const CloudConfig& config, User& user) override;
+
+    CloudStatus update(const CloudConfig& config, const User& user) override;
+
     CloudStatus
     retrieve(const CloudConfig& config, const std::string& userID, const std::string& email, User& user) override;
 
-    CloudStatus update(const CloudConfig& config, const User& user) override;
+    CloudStatus
+    update(const CloudConfig& config, const std::string& userID, const std::string& email, const User& user) override;
 
     CloudStatus remove(const CloudConfig& config, const std::string& userID, const std::string& email) override;
 

--- a/api-cpp-validator/src/UserValidator.cpp
+++ b/api-cpp-validator/src/UserValidator.cpp
@@ -45,6 +45,18 @@ CloudStatus UserValidator::list(const CloudConfig& config,
     return CloudStatus(CLOUD_OK);
 }
 
+CloudStatus UserValidator::retrieve(const CloudConfig& config, User& user)
+{
+    MACRO_RETURN_ERROR_IF_NO_USER_TOKEN(config);
+    return CloudStatus(CLOUD_OK);
+}
+
+CloudStatus UserValidator::update(const CloudConfig& config, const User& user)
+{
+    MACRO_RETURN_ERROR_IF_NO_USER_TOKEN(config);
+    return CloudStatus(CLOUD_OK);
+}
+
 CloudStatus
 UserValidator::retrieve(const CloudConfig& config, const std::string& userID, const std::string& email, User& user)
 {
@@ -54,9 +66,12 @@ UserValidator::retrieve(const CloudConfig& config, const std::string& userID, co
     return CloudStatus(CLOUD_OK);
 }
 
-CloudStatus UserValidator::update(const CloudConfig& config, const User& user)
+CloudStatus
+UserValidator::update(const CloudConfig& config, const std::string& userID, const std::string& email, const User& user)
 {
     MACRO_RETURN_ERROR_IF_NO_USER_TOKEN(config);
+    MACRO_RETURN_ERROR_IF_EMPTY(userID);
+    MACRO_RETURN_ERROR_IF_EMPTY(email);
     return CloudStatus(CLOUD_OK);
 }
 

--- a/api-cpp-websocket/CMakeLists.txt
+++ b/api-cpp-websocket/CMakeLists.txt
@@ -5,15 +5,15 @@ endif(NOT WITH_WEBSOCKET)
 add_definitions(-DWITH_WEBSOCKET)
 
 # Use an absolute reference here so that doxygen can locate in the doc context by target
-set(API_CPP_WEBSOCKET_PUBLIC_HEADERS
-    ${CMAKE_SOURCE_DIR}/api-cpp-websocket/include/dfx/api/websocket/DeviceWebSocket.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-websocket/include/dfx/api/websocket/LicenseWebSocket.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-websocket/include/dfx/api/websocket/MeasurementWebSocket.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-websocket/include/dfx/api/websocket/MeasurementStreamWebSocket.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-websocket/include/dfx/api/websocket/OrganizationWebSocket.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-websocket/include/dfx/api/websocket/ProfileWebSocket.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-websocket/include/dfx/api/websocket/StudyWebSocket.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp-websocket/include/dfx/api/websocket/UserWebSocket.hpp)
+set(API_CPP_WEBSOCKET_HEADERS
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/websocket/DeviceWebSocket.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/websocket/LicenseWebSocket.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/websocket/MeasurementWebSocket.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/websocket/MeasurementStreamWebSocket.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/websocket/OrganizationWebSocket.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/websocket/ProfileWebSocket.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/websocket/StudyWebSocket.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/websocket/UserWebSocket.hpp)
 
 add_library(
   api-cpp-websocket OBJECT
@@ -26,7 +26,7 @@ add_library(
   src/ProfileWebSocket.cpp
   src/StudyWebSocket.cpp
   src/UserWebSocket.cpp
-  ${API_CPP_WebSocket_PUBLIC_HEADERS})
+  ${API_CPP_WebSocket_HEADERS})
 
 if(MSVC)
   if(BUILD_SHARED_LIBS)
@@ -36,28 +36,19 @@ if(MSVC)
   target_compile_options(api-cpp-websocket PUBLIC /utf-8)
 endif()
 
-set_target_properties(api-cpp-websocket PROPERTIES DEFINE_SYMBOL "dfxapi_EXPORTS")
+set_target_properties(api-cpp-websocket PROPERTIES DEFINE_SYMBOL "dfxcloud_EXPORTS")
 
 target_include_directories(
   api-cpp-websocket
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-         $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-cpp,INTERFACE_INCLUDE_DIRECTORIES>>
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
          $<BUILD_INTERFACE:$<TARGET_PROPERTY:websocket,INTERFACE_INCLUDE_DIRECTORIES>>
-         $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-protos-web,INTERFACE_INCLUDE_DIRECTORIES>>)
-
-set_target_properties(api-cpp-websocket PROPERTIES PUBLIC_HEADER "${API_CPP_WEBSOCKET_PUBLIC_HEADERS}")
+  PRIVATE $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-cpp,INTERFACE_INCLUDE_DIRECTORIES>>
+          $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-cpp-validator,INTERFACE_INCLUDE_DIRECTORIES>>
+          $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-protos-web,INTERFACE_INCLUDE_DIRECTORIES>>)
 
 set_target_properties(api-cpp-websocket PROPERTIES CXX_VISIBILITY_PRESET hidden)
-# set_target_properties(api-cpp-websocket PROPERTIES CMAKE_VISIBILITY_INLINES_HIDDEN YES)
 
 target_link_libraries(
   api-cpp-websocket
-  api-protos-web
-  api-utils
-  websocket
-  $<$<NOT:$<PLATFORM_ID:Emscripten>>:CURL::libcurl>
-  fmt::fmt
-  nlohmann_json::nlohmann_json)
-
-install(TARGETS api-cpp-websocket PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dfx/api/webocket)
+  PRIVATE api-protos-web api-utils websocket $<$<NOT:$<PLATFORM_ID:Emscripten>>:CURL::libcurl> fmt::fmt
+          nlohmann_json::nlohmann_json)

--- a/api-cpp-websocket/include/dfx/api/websocket/UserWebSocket.hpp
+++ b/api-cpp-websocket/include/dfx/api/websocket/UserWebSocket.hpp
@@ -40,10 +40,15 @@ public:
                      std::vector<User>& users,
                      int16_t& totalCount) override;
 
+    CloudStatus retrieve(const CloudConfig& config, User& user) override;
+
+    CloudStatus update(const CloudConfig& config, const User& user) override;
+
     CloudStatus
     retrieve(const CloudConfig& config, const std::string& userID, const std::string& email, User& user) override;
 
-    CloudStatus update(const CloudConfig& config, const User& user) override;
+    CloudStatus
+    update(const CloudConfig& config, const std::string& userID, const std::string& email, const User& user) override;
 
     CloudStatus remove(const CloudConfig& config, const std::string& email, const std::string& userID) override;
 

--- a/api-cpp-websocket/src/UserWebSocket.cpp
+++ b/api-cpp-websocket/src/UserWebSocket.cpp
@@ -92,6 +92,55 @@ CloudStatus UserWebSocket::list(const CloudConfig& config,
     return status;
 }
 
+CloudStatus UserWebSocket::retrieve(const CloudConfig& config, User& user)
+{
+    DFX_CLOUD_VALIDATOR_MACRO(UserValidator, retrieve(config, user));
+    dfx::proto::users::RetrieveRequest request;
+    dfx::proto::users::RetrieveResponse response;
+
+    auto status = cloudWebSocket->sendMessage(dfx::api::web::Users::Retrieve, request, response);
+    if (status.OK()) {
+        user.id = response.id();
+        user.firstName = response.firstname();
+        user.lastName = response.lastname();
+        user.email = response.email();
+        user.gender = response.gender();
+        user.dateOfBirth = response.dateofbirth();
+        user.avatarURL = response.avataruri();
+        user.createdEpochSeconds = response.created();
+        user.updatedEpochSeconds = response.updated();
+        user.role = response.roleid();
+        user.phoneNumber = response.phonenumber();
+        user.isVerified = response.isverified();
+        user.verificationCode = response.verificationcode();
+        user.heightCM = response.heightcm();
+        user.weightKG = response.weightkg();
+        user.loginMethod = response.loginmethod();
+        user.ssoID = response.ssoid();
+    }
+    return status;
+}
+
+CloudStatus UserWebSocket::update(const CloudConfig& config, const User& user)
+{
+    DFX_CLOUD_VALIDATOR_MACRO(UserValidator, update(config, user));
+    dfx::proto::users::UpdateRequest request;
+    dfx::proto::users::UpdateResponse response;
+
+    request.set_email(user.email);
+    request.set_firstname(user.firstName);
+    request.set_lastname(user.lastName);
+    request.set_password(user.password);
+    request.set_gender(user.gender);
+    request.set_dateofbirth(user.dateOfBirth);
+    request.set_phonenumber(user.phoneNumber);
+    request.set_heightcm(user.heightCM);
+    request.set_weightkg(user.weightKG);
+
+    auto status = cloudWebSocket->sendMessage(dfx::api::web::Users::Update, request, response);
+    return status;
+}
+
 CloudStatus
 UserWebSocket::retrieve(const CloudConfig& config, const std::string& userID, const std::string& email, User& user)
 {
@@ -122,9 +171,10 @@ UserWebSocket::retrieve(const CloudConfig& config, const std::string& userID, co
     return status;
 }
 
-CloudStatus UserWebSocket::update(const CloudConfig& config, const User& user)
+CloudStatus
+UserWebSocket::update(const CloudConfig& config, const std::string& userID, const std::string& email, const User& user)
 {
-    DFX_CLOUD_VALIDATOR_MACRO(UserValidator, update(config, user));
+    DFX_CLOUD_VALIDATOR_MACRO(UserValidator, update(config, userID, email, user));
     dfx::proto::users::UpdateRequest request;
     dfx::proto::users::UpdateResponse response;
 

--- a/api-cpp/CMakeLists.txt
+++ b/api-cpp/CMakeLists.txt
@@ -1,28 +1,30 @@
 # Use an absolute reference here so that doxygen can locate in the doc context by target
 set(API_CPP_PUBLIC_HEADERS
     ${CMAKE_BINARY_DIR}/include/dfx/api/CloudAPI_Export.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/CloudAPI.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/CloudConfig.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/CloudLog.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/CloudStatus.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/CloudTypes.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/DeviceAPI.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/LicenseAPI.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/MeasurementAPI.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/MeasurementStreamAPI.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/OrganizationAPI.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/ProfileAPI.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/SignalAPI.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/StudyAPI.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/UserAPI.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/types/DeviceTypes.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/types/LicenseTypes.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/types/MeasurementTypes.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/types/OrganizationTypes.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/types/ProfileTypes.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/types/SignalTypes.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/types/StudyTypes.hpp
-    ${CMAKE_SOURCE_DIR}/api-cpp/include/dfx/api/types/UserTypes.hpp)
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/CloudAPI.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/CloudConfig.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/CloudLog.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/CloudStatus.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/CloudTypes.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/DeviceAPI.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/LicenseAPI.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/MeasurementAPI.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/MeasurementStreamAPI.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/OrganizationAPI.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/ProfileAPI.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/SignalAPI.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/StudyAPI.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/UserAPI.hpp)
+
+set(API_TYPES_CPP_PUBLIC_HEADERS
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/types/DeviceTypes.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/types/LicenseTypes.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/types/MeasurementTypes.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/types/OrganizationTypes.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/types/ProfileTypes.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/types/SignalTypes.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/types/StudyTypes.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/types/UserTypes.hpp)
 
 add_library(
   api-cpp OBJECT
@@ -52,6 +54,9 @@ add_library(
   ${CMAKE_BINARY_DIR}/version_info.cpp
   ${API_CPP_PUBLIC_HEADERS})
 
+# These install to a separate folder but when they were clumped, they all installed to the same destination
+add_library(api-cpp-types INTERFACE ${API_TYPES_CPP_PUBLIC_HEADERS})
+
 if(MSVC)
   # Silence the Microsoft compiler warnings C4996/STL4015, for generated gRPC code when building with C++17
   if(CMAKE_CXX_STANDARD GREATER_EQUAL 17)
@@ -64,29 +69,33 @@ if(MSVC)
   target_compile_options(api-cpp PUBLIC /utf-8)
 endif()
 
-target_compile_definitions(api-cpp PRIVATE -Ddfxapi_EXPORTS)
+target_compile_definitions(api-cpp PRIVATE -Ddfxcloud_EXPORTS)
 
 target_include_directories(
   api-cpp
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include> # For CloudAPI_Export.hpp
+  PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include> # For CloudAPI_Export.hpp
+  PRIVATE
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/> # For version_info.hpp
+    $<BUILD_INTERFACE:$<TARGET_PROPERTY:fmt::fmt,INTERFACE_INCLUDE_DIRECTORIES>>
     $<BUILD_INTERFACE:$<TARGET_PROPERTY:api-cpp-validator,INTERFACE_INCLUDE_DIRECTORIES>> # stub if not
                                                                                           # WITH_VALIDATORS
-    $<$<BOOL:${WITH_GRPC}>:$<BUILD_INTERFACE:$<TARGET_PROPERTY:api-cpp-grpc,INTERFACE_INCLUDE_DIRECTORIES>>>
-    $<$<BOOL:${WITH_REST}>:$<BUILD_INTERFACE:$<TARGET_PROPERTY:api-cpp-rest,INTERFACE_INCLUDE_DIRECTORIES>>>
-    $<$<BOOL:${WITH_WEBSOCKET}>:$<BUILD_INTERFACE:$<TARGET_PROPERTY:api-cpp-websocket,INTERFACE_INCLUDE_DIRECTORIES>>>
 )
 
 set_target_properties(api-cpp PROPERTIES PUBLIC_HEADER "${API_CPP_PUBLIC_HEADERS}")
+set_target_properties(api-cpp-types PROPERTIES PUBLIC_HEADER "${API_TYPES_CPP_PUBLIC_HEADERS}")
 
-target_link_libraries(api-cpp PRIVATE $<$<BOOL:${WITH_YAML}>:yaml-cpp::yaml-cpp> nlohmann_json::nlohmann_json)
+target_link_libraries(
+  api-cpp
+  PUBLIC nlohmann_json::nlohmann_json api-cpp-types
+  PRIVATE $<BUILD_INTERFACE:api-utils>
+          $<BUILD_INTERFACE:$<$<BOOL:${WITH_YAML}>:yaml-cpp::yaml-cpp>>
+          $<BUILD_INTERFACE:$<$<BOOL:${WITH_GRPC}>:api-cpp-grpc>>
+          $<BUILD_INTERFACE:$<$<BOOL:${WITH_REST}>:api-cpp-rest>>
+          $<BUILD_INTERFACE:$<$<BOOL:${WITH_WEBSOCKET}>:api-cpp-websocket>>)
 
 if(EMBED_CA_CERTS)
   embed_file("cacert" "${CMAKE_SOURCE_DIR}/resources/cacert.pem" cacert.c)
-
-  # embed_file("cacert" "${CMAKE_BINARY_DIR}/res/cacert.pem" cacert.c)
   target_compile_definitions(api-cpp PRIVATE EMBED_CA_CERTS)
 endif(EMBED_CA_CERTS)
 
@@ -110,4 +119,11 @@ if(WITH_YAML)
   target_compile_definitions(api-cpp PRIVATE WITH_YAML)
 endif(WITH_YAML)
 
-install(TARGETS api-cpp PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dfx/api)
+install(
+  TARGETS api-cpp
+  EXPORT DFXCloud-export
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dfx/api)
+install(
+  TARGETS api-cpp-types
+  EXPORT DFXCloud-export
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dfx/api/types)

--- a/api-cpp/CMakeLists.txt
+++ b/api-cpp/CMakeLists.txt
@@ -89,6 +89,7 @@ target_link_libraries(
   api-cpp
   PUBLIC nlohmann_json::nlohmann_json api-cpp-types
   PRIVATE $<BUILD_INTERFACE:api-utils>
+          $<BUILD_INTERFACE:$<$<BOOL:${WITH_CURL}>:CURL::libcurl>>
           $<BUILD_INTERFACE:$<$<BOOL:${WITH_YAML}>:yaml-cpp::yaml-cpp>>
           $<BUILD_INTERFACE:$<$<BOOL:${WITH_GRPC}>:api-cpp-grpc>>
           $<BUILD_INTERFACE:$<$<BOOL:${WITH_REST}>:api-cpp-rest>>

--- a/api-cpp/include/dfx/api/UserAPI.hpp
+++ b/api-cpp/include/dfx/api/UserAPI.hpp
@@ -131,6 +131,33 @@ public:
 
     /**
      * \~english
+     * @brief Retrieve user information for the currently connected user.
+     *
+     * @param config provides all the cloud configuration settings
+     * @param user account information for current user
+     * @return status of operation, CLOUD_OK on SUCCESS
+     */
+    virtual CloudStatus retrieve(const CloudConfig& config, User& user);
+
+    /**
+     * \~english
+     * @brief Update the currently connected user.
+     *
+     * @param config provides all the cloud configuration settings
+     * @param user account details to update
+     * @return status of operation, CLOUD_OK on SUCCESS
+     *
+     * \~chinese
+     * @brief 更新用户
+     *
+     * @param config 服务配置参数
+     * @param user 用户信息
+     * @return 接口返回值 CLOUD_OK:成功
+     */
+    virtual CloudStatus update(const CloudConfig& config, const User& user);
+
+    /**
+     * \~english
      * @brief Retrieve a user from the server based on the userID and/or email.
      *
      * \verbatim embed:rst:leading-asterisk
@@ -175,7 +202,8 @@ public:
      * @param user 用户信息
      * @return 接口返回值 CLOUD_OK:成功
      */
-    virtual CloudStatus update(const CloudConfig& config, const User& user);
+    virtual CloudStatus
+    update(const CloudConfig& config, const std::string& userID, const std::string& email, const User& user);
 
     /**
      * \~english

--- a/api-cpp/include/dfx/api/types/UserTypes.hpp
+++ b/api-cpp/include/dfx/api/types/UserTypes.hpp
@@ -37,7 +37,6 @@ using User = struct User
     uint16_t heightCM;
     uint16_t weightKG;
     std::string avatarURL;
-    uint64_t dateOfBirthEpochSeconds;
     uint64_t createdEpochSeconds;
     uint64_t updatedEpochSeconds;
     std::string password;

--- a/api-cpp/src/CloudLog.cpp
+++ b/api-cpp/src/CloudLog.cpp
@@ -47,7 +47,7 @@ void dfx::api::cloudLogSetLevel(int logLevel)
 {
     loggingLevel = logLevel;
 
- #if defined(WITH_GRPC) && !defined(_WIN32)
+#if defined(WITH_GRPC) && !defined(_WIN32)
     switch (logLevel) {
         case CLOUD_LOG_LEVEL_NONE:
             unsetenv(GRPC_VERBOSITY.c_str());

--- a/api-cpp/src/CloudLog.cpp
+++ b/api-cpp/src/CloudLog.cpp
@@ -35,7 +35,7 @@ void dfx::api::cloudLogSetEnabled(bool enabled)
 
 bool dfx::api::cloudLogIsActive(int logLevel)
 {
-    return true;
+    return cloudLogLevel() >= logLevel;
 }
 
 int dfx::api::cloudLogLevel()

--- a/api-cpp/src/UserAPI.cpp
+++ b/api-cpp/src/UserAPI.cpp
@@ -30,13 +30,24 @@ CloudStatus UserAPI::list(const CloudConfig& config,
     return CloudStatus(CLOUD_UNIMPLEMENTED_FEATURE);
 }
 
+CloudStatus UserAPI::retrieve(const CloudConfig& config, User& user)
+{
+    return CloudStatus(CLOUD_UNIMPLEMENTED_FEATURE);
+}
+
+CloudStatus UserAPI::update(const CloudConfig& config, const User& user)
+{
+    return CloudStatus(CLOUD_UNIMPLEMENTED_FEATURE);
+}
+
 CloudStatus
 UserAPI::retrieve(const CloudConfig& config, const std::string& userID, const std::string& email, User& user)
 {
     return CloudStatus(CLOUD_UNIMPLEMENTED_FEATURE);
 }
 
-CloudStatus UserAPI::update(const CloudConfig& config, const User& user)
+CloudStatus
+UserAPI::update(const CloudConfig& config, const std::string& userID, const std::string& email, const User& user)
 {
     return CloudStatus(CLOUD_UNIMPLEMENTED_FEATURE);
 }

--- a/api-cpp/src/UserTypes.cpp
+++ b/api-cpp/src/UserTypes.cpp
@@ -52,7 +52,7 @@ void dfx::api::to_json(nlohmann::json& j, const User& u)
     setJSONFieldIfNotDefault(j, "HeightCM", u.heightCM);
     setJSONFieldIfNotDefault(j, "WeightKG", u.weightKG);
     setJSONFieldIfNotDefault(j, "AvatarURL", u.avatarURL);
-    setJSONFieldIfNotDefault(j, "DateOfBirth", u.dateOfBirthEpochSeconds);
+    setJSONFieldIfNotDefault(j, "DateOfBirth", u.dateOfBirth);
     setJSONFieldIfNotDefault(j, "Created", u.createdEpochSeconds);
     setJSONFieldIfNotDefault(j, "Updated", u.updatedEpochSeconds);
     setJSONFieldIfNotDefault(j, "Password", u.password);
@@ -74,7 +74,7 @@ void dfx::api::from_json(const nlohmann::json& j, User& u)
 {
     getValidField(j, "ID", u.id);
     getValidField(j, "Gender", u.gender);
-    getValidField(j, "DateOfBirth", u.dateOfBirthEpochSeconds);
+    getValidField(j, "DateOfBirth", u.dateOfBirth);
     getValidField(j, "Created", u.createdEpochSeconds);
     getValidField(j, "Updated", u.updatedEpochSeconds);
     getValidField(j, "OrganizationID", u.organizationID);

--- a/api-protos-grpc/CMakeLists.txt
+++ b/api-protos-grpc/CMakeLists.txt
@@ -26,7 +26,6 @@ add_library(
 if(MSVC AND CMAKE_CXX_STANDARD GREATER_EQUAL 17)
   target_compile_definitions(api-protos-grpc
                              PUBLIC "-D_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING")
-  # target_compile_options(api-protos-grpc PUBLIC /wd4244 /wd4267 /wd4996)
   target_compile_options(api-protos-grpc PUBLIC /utf-8)
 else()
   # Ignore Protobuf password deprecations warning: 'password' is deprecated [-Wdeprecated-declarations]

--- a/api-utils/CMakeLists.txt
+++ b/api-utils/CMakeLists.txt
@@ -1,22 +1,25 @@
 # add_definitions(-DWITH_VALIDATORS)
 
 # Use an absolute reference here so that doxygen can locate in the doc context by target
-set(API_UTILS_PUBLIC_HEADERS ${CMAKE_SOURCE_DIR}/api-utils/include/dfx/api/utils/HexDump.hpp
-                             ${CMAKE_SOURCE_DIR}/api-utils/include/dfx/api/utils/FileUtils.hpp)
+set(API_UTILS_PUBLIC_HEADERS ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/utils/HexDump.hpp
+                             ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/utils/FileUtils.hpp)
 
-add_library(api-utils OBJECT src/HexDump.cpp src/FileUtils.cpp)
+add_library(api-utils OBJECT src/HexDump.cpp src/FileUtils.cpp ${API_UTILS_PUBLIC_HEADERS})
 
-set_target_properties(api-utils PROPERTIES DEFINE_SYMBOL "dfxapi_EXPORTS")
+set_target_properties(api-utils PROPERTIES DEFINE_SYMBOL "dfxcloud_EXPORTS")
 
 target_include_directories(
   api-utils PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>) # For CloudAPI_Export.hpp
 
-target_link_libraries(api-utils PRIVATE fmt::fmt)
+target_link_libraries(api-utils PRIVATE $<BUILD_INTERFACE:fmt::fmt>)
 
 set_target_properties(api-utils PROPERTIES PUBLIC_HEADER "${API_UTILS_PUBLIC_HEADERS}")
 
 set_target_properties(api-utils PROPERTIES CXX_VISIBILITY_PRESET hidden)
 set_target_properties(api-utils PROPERTIES CMAKE_VISIBILITY_INLINES_HIDDEN YES)
 
-install(TARGETS api-utils PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dfx/api/utils)
+install(
+  TARGETS api-utils
+  EXPORT DFXCloud-export
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dfx/api/utils)

--- a/cmake/DFXCloudConfig.cmake
+++ b/cmake/DFXCloudConfig.cmake
@@ -1,0 +1,2 @@
+include(CMakeFindDependencyMacro)
+include("${CMAKE_CURRENT_LIST_DIR}/DFXCloudTargets.cmake")

--- a/cmake/find_dependencies.cmake
+++ b/cmake/find_dependencies.cmake
@@ -23,7 +23,9 @@ if(WITH_GRPC)
   find_package(gRPC CONFIG REQUIRED) # gRPC::grpc++
 endif(WITH_GRPC)
 
-find_package(CURL CONFIG) # CURL::libcurl
+if(WITH_CURL)
+  find_package(CURL CONFIG REQUIRED) # CURL::libcurl
+endif(WITH_CURL)
 
 if(WITH_WEBSOCKET)
   find_package(Libwebsockets CONFIG REQUIRED) # Libwebsockets::libwebsockets

--- a/cmake/find_dependencies.cmake
+++ b/cmake/find_dependencies.cmake
@@ -29,16 +29,6 @@ if(WITH_WEBSOCKET)
   find_package(Libwebsockets CONFIG REQUIRED) # Libwebsockets::libwebsockets
 endif(WITH_WEBSOCKET)
 
-if(WITH_TESTS)
-  find_package(GTest CONFIG REQUIRED)
-  find_package(gflags CONFIG REQUIRED)
-endif(WITH_TESTS)
-
-if(WITH_DFXCLI)
-  find_package(CLI11 CONFIG REQUIRED)
-  find_package(naturalsort CONFIG REQUIRED)
-endif()
-
 # Handles importing files from the PACKAGE_FOLDERS, analogous to ConanFile::imports() stage. Since the conan
 # imports() is broken for private requirements when using build contexts they are written here.
 #

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,8 +3,9 @@
 from conans import ConanFile, MSBuild, tools
 from conans.tools import os_info, SystemPackageTool
 from conan.tools.cmake import CMakeToolchain, CMake, CMakeDeps
+from conans.tools import load
 
-import os, sys, subprocess
+import os, sys, re, subprocess
 
 # https://stackoverflow.com/a/42580137
 def get_base_prefix_compat():
@@ -13,9 +14,18 @@ def get_base_prefix_compat():
 def in_virtualenv():
     return get_base_prefix_compat() != sys.prefix
 
+def get_version():
+    try:
+        content = load("CMakeLists.txt")
+        version = re.search("set\(DFX_CLOUD_LIBRARY_VERSION (.*)\)", content).group(1)
+        return version.strip()
+    except Exception as e:
+        print("Exception obtaining version: {}".format(e))
+        return None
+
 class dfxcloud(ConanFile):
     name = "dfxcloud"
-    version = "1.0.0"
+    version = get_version()
     license = "Nuralogix License"
     url = "https://github.com/nuralogix/dfx-api-client-cpp"
     description = "The DFX API facilitates data communication with a DFX Server"
@@ -237,8 +247,8 @@ class dfxcloud(ConanFile):
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
 
-        # Generate dfxcloud-config.cmake
-        self.cpp_info.set_property("cmake_file_name", "dfxcloud")
+        # Generate DFXCloud-config.cmake
+        self.cpp_info.set_property("cmake_file_name", "DFXCloud")
 
         # DFXCloud:: namespace for the targets
         self.cpp_info.set_property("cmake_target_name", "DFXCloud")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -46,7 +46,8 @@ set(DOXYGEN_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}) # folders are named like api
 
 add_custom_target(
   SphinxHTML ALL
-  COMMAND ${CMAKE_COMMAND} -E env "CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}"
+  COMMAND
+    ${CMAKE_COMMAND} -E env "CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}"
     # Sphinx Executable sphinx-build is a Python script, but would use it's own virtual environment and we
     # need to let our virtual environment containing sphinx_rtd_theme, rst2pdf etc. take precedence.
     ${Python_EXECUTABLE} ${SPHINX_EXECUTABLE} -b html
@@ -75,7 +76,8 @@ add_custom_target(
 
 add_custom_target(
   SphinxLatex ALL
-  COMMAND ${CMAKE_COMMAND} -E env "CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}"
+  COMMAND
+    ${CMAKE_COMMAND} -E env "CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}"
     # Sphinx Executable sphinx-build is a Python script, but would use it's own virtual environment and we
     # need to let our virtual environment containing sphinx_rtd_theme, rst2pdf etc. take precedence.
     ${Python_EXECUTABLE} ${SPHINX_EXECUTABLE} -b latex

--- a/doc/api-protos-grpc-doxygen/CMakeLists.txt
+++ b/doc/api-protos-grpc-doxygen/CMakeLists.txt
@@ -9,8 +9,8 @@ set(DOXYGEN_INDEX_FILE ${DOXYGEN_OUTPUT_DIR}/html/index.html)
 set(DOXYFILE_IN Doxyfile.in)
 set(DOXYFILE_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
 
-# These are injected via conan package protomatlabdoxygen which establishes the CMAKE_PROGRAM_PATH
-# which find_program uses to locate the binary. They are then substituted in the configure_file.
+# These are injected via conan package protomatlabdoxygen which establishes the CMAKE_PROGRAM_PATH which
+# find_program uses to locate the binary. They are then substituted in the configure_file.
 find_program(PROTO2CPP_BINPATH proto2cpp.py)
 find_program(M2CPP_BINPATH m2cpp.pl)
 

--- a/doc/api-protos-web-doxygen/CMakeLists.txt
+++ b/doc/api-protos-web-doxygen/CMakeLists.txt
@@ -9,8 +9,8 @@ set(DOXYGEN_INDEX_FILE ${DOXYGEN_OUTPUT_DIR}/html/index.html)
 set(DOXYFILE_IN Doxyfile.in)
 set(DOXYFILE_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
 
-# These are injected via conan package protomatlabdoxygen which establishes the CMAKE_PROGRAM_PATH
-# which find_program uses to locate the binary. They are then substituted in the configure_file.
+# These are injected via conan package protomatlabdoxygen which establishes the CMAKE_PROGRAM_PATH which
+# find_program uses to locate the binary. They are then substituted in the configure_file.
 find_program(PROTO2CPP_BINPATH proto2cpp.py)
 find_program(M2CPP_BINPATH m2cpp.pl)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,24 @@
-if(NOT WITH_TESTS)
-  return()
-endif()
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+project(test-cloud-api LANGUAGES CXX C)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
 # https://grpc.github.io/grpc/cpp/md_doc_unit_testing.html
+
+find_package(GTest CONFIG REQUIRED)
+find_package(gflags CONFIG REQUIRED)
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  find_package(DFXCloud CONFIG REQUIRED)
+  find_package(nlohmann_json CONFIG REQUIRED) # Dependency of DFXCloud
+endif()
+
+include(CTest)
+include(GoogleTest)
+enable_testing()
 
 add_executable(
   test-cloud-api
@@ -31,7 +47,7 @@ endif(MSVC)
 # set_target_properties(test-cloud-api PROPERTIES CXX_VISIBILITY_PRESET default)
 # set_target_properties(test-cloud-api PROPERTIES CMAKE_VISIBILITY_INLINES_HIDDEN NO)
 # target_compile_definitions(test-cloud-api PUBLIC GTEST_API_=)
-target_link_libraries(test-cloud-api PRIVATE dfxapi gtest::gtest gflags::gflags)
+target_link_libraries(test-cloud-api PRIVATE DFXCloud::dfxcloud gtest::gtest gflags::gflags fmt::fmt)
 
 target_include_directories(test-cloud-api PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
@@ -43,7 +59,7 @@ elseif(WIN32)
   add_custom_command(
     TARGET test-cloud-api
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:dfxapi> $<TARGET_FILE_DIR:test-cloud-api>)
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:dfxcloud> $<TARGET_FILE_DIR:test-cloud-api>)
 else()
   set_target_properties(test-cloud-api PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
 endif()

--- a/tool-dfxcli/CMakeLists.txt
+++ b/tool-dfxcli/CMakeLists.txt
@@ -1,20 +1,24 @@
-if(NOT WITH_DFXCLI)
-  return() # Only supported if built WITH_DFXCLI
-endif(NOT WITH_DFXCLI)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+project(dfxcli LANGUAGES CXX C)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
 set(DFXCLI_HEADERS
-    ${CMAKE_SOURCE_DIR}/tool-dfxcli/include/dfx/api/cli/AuthCommands.hpp
-    ${CMAKE_SOURCE_DIR}/tool-dfxcli/include/dfx/api/cli/ConfigCommand.hpp
-    ${CMAKE_SOURCE_DIR}/tool-dfxcli/include/dfx/api/cli/DeviceCommand.hpp
-    ${CMAKE_SOURCE_DIR}/tool-dfxcli/include/dfx/api/cli/DFXAppCommand.hpp
-    ${CMAKE_SOURCE_DIR}/tool-dfxcli/include/dfx/api/cli/LicenseCommand.hpp
-    ${CMAKE_SOURCE_DIR}/tool-dfxcli/include/dfx/api/cli/MeasurementCommand.hpp
-    ${CMAKE_SOURCE_DIR}/tool-dfxcli/include/dfx/api/cli/OrganizationCommand.hpp
-    ${CMAKE_SOURCE_DIR}/tool-dfxcli/include/dfx/api/cli/ProfileCommand.hpp
-    ${CMAKE_SOURCE_DIR}/tool-dfxcli/include/dfx/api/cli/SignalCommand.hpp
-    ${CMAKE_SOURCE_DIR}/tool-dfxcli/include/dfx/api/cli/StatusCommand.hpp
-    ${CMAKE_SOURCE_DIR}/tool-dfxcli/include/dfx/api/cli/StudyCommand.hpp
-    ${CMAKE_SOURCE_DIR}/tool-dfxcli/include/dfx/api/cli/UserCommand.hpp)
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/cli/AuthCommands.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/cli/ConfigCommand.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/cli/DeviceCommand.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/cli/DFXAppCommand.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/cli/LicenseCommand.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/cli/MeasurementCommand.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/cli/OrganizationCommand.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/cli/ProfileCommand.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/cli/SignalCommand.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/cli/StatusCommand.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/cli/StudyCommand.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/dfx/api/cli/UserCommand.hpp)
 
 add_executable(
   dfxcli
@@ -35,7 +39,16 @@ add_executable(
 
 target_include_directories(dfxcli PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
-target_link_libraries(dfxcli PRIVATE dfxapi CLI11::CLI11 naturalsort::naturalsort fmt::fmt)
+find_package(CLI11 CONFIG REQUIRED)
+find_package(naturalsort CONFIG REQUIRED)
+find_package(fmt CONFIG REQUIRED)
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  find_package(DFXCloud CONFIG REQUIRED)
+  find_package(nlohmann_json CONFIG REQUIRED) # Dependency of DFXCloud
+endif()
+
+target_link_libraries(dfxcli PRIVATE DFXCloud::dfxcloud CLI11::CLI11 naturalsort::naturalsort fmt::fmt)
 
 if(APPLE)
   set_target_properties(dfxcli PROPERTIES INSTALL_RPATH "@executable_path/../lib")
@@ -45,7 +58,7 @@ elseif(WIN32)
   add_custom_command(
     TARGET dfxcli
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:dfxapi> $<TARGET_FILE_DIR:dfxcli>)
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:dfxcloud> $<TARGET_FILE_DIR:dfxcli>)
 else()
   set_target_properties(dfxcli PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib")
 endif()

--- a/tool-dfxcli/include/dfx/api/cli/UserCommand.hpp
+++ b/tool-dfxcli/include/dfx/api/cli/UserCommand.hpp
@@ -14,6 +14,9 @@ class UserGetCommand : public DFXAppCommand
 public:
     UserGetCommand(CLI::App* get, std::shared_ptr<Options> options, DFXExitCode& result);
     DFXExitCode execute() override;
+
+private:
+    bool operateOnSelf;
 };
 
 #endif // DFXAPI_USERCOMMAND_HPP

--- a/tool-dfxcli/src/UserCommand.cpp
+++ b/tool-dfxcli/src/UserCommand.cpp
@@ -10,9 +10,10 @@ using dfx::api::User;
 using nlohmann::json;
 
 UserGetCommand::UserGetCommand(CLI::App* get, std::shared_ptr<Options> options, DFXExitCode& result)
-    : DFXAppCommand(std::move(options))
+    : DFXAppCommand(std::move(options)), operateOnSelf(false)
 {
     cmd = createGetCommand(get, "user");
+    cmd->add_flag("-s,--self", operateOnSelf, "Operate on self");
     cmd->callback([&]() { result = cleanup(setupAndExecute()); });
 }
 
@@ -25,6 +26,12 @@ DFXExitCode UserGetCommand::execute()
         return DFXExitCode::FAILURE;
     }
 
+    if (operateOnSelf && ids.size() > 0) {
+        CloudStatus status(CLOUD_PARAMETER_VALIDATION_ERROR, "No ids are allowed when operating on self");
+        outputError(status);
+        return DFXExitCode::FAILURE;
+    }
+
     // If specified on command line, override the config limit
     if (cmd->count("--limit") > 0) {
         config.listLimit = limit;
@@ -32,10 +39,31 @@ DFXExitCode UserGetCommand::execute()
 
     int16_t totalCount;
     std::vector<User> users;
-    auto status = user->list(config, {}, offset, users, totalCount);
+    User self;
+    CloudStatus status(CLOUD_OK);
+    if (operateOnSelf) {
+        status = user->retrieve(config, self);
+    } else {
+        if (ids.size() == 0) {
+            status = user->list(config, {}, offset, users, totalCount);
+        } else {
+            for (auto id : ids) {
+                User u;
+                std::string email(""); // How best to specify on CLI?
+                status = user->retrieve(config, id, email, u);
+                if (status.OK()) {
+                    users.push_back(u);
+                }
+            }
+        }
+    }
 
     if (status.code == CLOUD_OK) {
-        outputResponse({{"users", users}, {"total", totalCount}});
+        if (operateOnSelf) {
+            outputResponse({{"user", self}, {"total", 1}});
+        } else {
+            outputResponse({{"users", users}, {"total", totalCount}});
+        }
         return DFXExitCode::SUCCESS;
     } else {
         outputError(status);

--- a/websocket/CMakeLists.txt
+++ b/websocket/CMakeLists.txt
@@ -4,19 +4,15 @@ endif(NOT WITH_WEBSOCKET)
 
 add_definitions(-DWITH_WEBSOCKET)
 
-set(WEBSOCKET_PUBLIC_HEADERS ${CMAKE_SOURCE_DIR}/websocket/include/dfx/websocket/WebSocket.hpp)
+set(WEBSOCKET_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/dfx/websocket/WebSocket.hpp)
 
 add_library(
   websocket OBJECT
   src/WebSocket.cpp $<$<NOT:$<BOOL:${EMSCRIPTEN}>>:src/WebSocketLibWebSocket.cpp>
-  $<$<NOT:$<BOOL:${EMSCRIPTEN}>>:include/dfx/websocket/WebSocketLibWebSocket.hpp> ${WEBSOCKET_PUBLIC_HEADERS})
+  $<$<NOT:$<BOOL:${EMSCRIPTEN}>>:include/dfx/websocket/WebSocketLibWebSocket.hpp> ${WEBSOCKET_HEADERS})
 
 target_include_directories(websocket PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
-
-set_target_properties(websocket PROPERTIES PUBLIC_HEADER "${WEBSOCKET_PUBLIC_HEADERS}")
 
 set_target_properties(websocket PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
 target_link_libraries(websocket $<$<NOT:$<BOOL:${EMSCRIPTEN}>>:websockets>)
-
-install(TARGETS websocket PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dfx/websocket)


### PR DESCRIPTION
- CMake improvements to create installable packages with associated CMake config files. 
- Tightened dependencies across object libraries
- dfxcli & test are proper CMake projects, ie. can be built independent (assuming libdfxcloud.so available)
- Version details captured in CMakeLists for library project and ingested into conanfile
- Added support for User self retrieve/update
- Improved Justfile support options, using type=Release instead of t=Release
- Exposed option to build static library, in addition to default dynamic