### PR TITLE
Fixed issue with WebSocket measurement stream non-default timeout bei…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.3.1]
+ - Fixed bug in WebSocket MeasurementStreamAPI.waitForCompletion when
+   timeout was not the default wait forever value.
+
 ## [1.3.0]
  - Added support for passing WebSocket MeasurementStream properties
    during stream setup for things like resolution and streaming.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 # conanfile.py parses next line to determine version which feeds the version to everything
-set(DFX_CLOUD_LIBRARY_VERSION 1.3.0)
+set(DFX_CLOUD_LIBRARY_VERSION 1.3.1)
 
 project(
   dfxcloud

--- a/api-cpp/src/MeasurementStreamAPI.cpp
+++ b/api-cpp/src/MeasurementStreamAPI.cpp
@@ -173,7 +173,7 @@ CloudStatus MeasurementStreamAPI::waitForCompletion(const CloudConfig& config, i
 {
     std::unique_lock<std::mutex> lock(measurementMutex);
     if (!measurementClosed) { // Need to check before waiting on condition, reader thread may never set
-        if (timeoutMillis >= 0) {
+        if (timeoutMillis == 0) {
             cvWaitForCompletion.wait(lock); // User wants to wait until we get notified
         } else {
             if (std::cv_status::timeout == cvWaitForCompletion.wait_for(lock, timeoutMillis * 1ms)) {


### PR DESCRIPTION
Timeout value was being treated incorrectly.