### PR TITLE
Propagate the result in MeasurementStream sendChunk failures

### DIFF
--- a/api-cpp-websocket-json/src/MeasurementStreamJsonWebSocket.cpp
+++ b/api-cpp-websocket-json/src/MeasurementStreamJsonWebSocket.cpp
@@ -196,7 +196,8 @@ CloudStatus MeasurementStreamWebSocketJson::sendChunk(const CloudConfig& config,
         cloudLog(CLOUD_LOG_LEVEL_WARNING, "WEB: Send not okay %d: %s", result.code, result.message.c_str());
 
         // Our write failed, connection bad close stream and return status
-        return closeStream();
+        closeStream();
+        return result;
     }
 
     chunksOutstanding++;

--- a/api-cpp-websocket-protobuf/src/MeasurementStreamWebSocketProtobuf.cpp
+++ b/api-cpp-websocket-protobuf/src/MeasurementStreamWebSocketProtobuf.cpp
@@ -205,7 +205,8 @@ CloudStatus MeasurementStreamWebSocketProtobuf::sendChunk(const CloudConfig& con
         cloudLog(CLOUD_LOG_LEVEL_WARNING, "WEB: Send not okay %d: %s", status.code, status.message.c_str());
 
         // Our write failed, connection bad close stream and return status
-        return closeStream();
+        closeStream();
+        return status;
     }
 
     chunksOutstanding++;


### PR DESCRIPTION
When calling the underlying WebSocket sendMessage, the underlying channel failure result was being dropped which is now passed to the client.